### PR TITLE
feat: add `focusable` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ marked("# heading");
 
 ## `options`
 
-| option |  type  | default | description                     |
-|--------|--------|---------|:--------------------------------|
-| prefix | string |  `""`   | A string to prepend to all ids. |
+| option    | type    | default | description                                                                          |
+| --------- | ------- | ------- | :----------------------------------------------------------------------------------- |
+| prefix    | string  | `""`    | A string to prepend to all ids.                                                      |
+| focusable | boolean | `false` | Includes the attribute `tabindex="-1"` to make headings focusable for accessibility. |

--- a/lib/index.cjs
+++ b/lib/index.cjs
@@ -84,7 +84,7 @@ let slugger;
 
 let headings = [];
 
-function gfmHeadingId({ prefix = '' } = {}) {
+function gfmHeadingId({ prefix = '', focusable = false } = {}) {
   return {
     headerIds: false, // prevent deprecation warning; remove this once headerIds option is removed
     hooks: {
@@ -104,7 +104,7 @@ function gfmHeadingId({ prefix = '' } = {}) {
         const heading = { level, text, id };
         headings.push(heading);
 
-        return `<h${level} id="${id}">${text}</h${level}>\n`;
+        return `<h${level} id="${id}"${focusable ? ' tabindex="-1"' : ''}>${text}</h${level}>\n`;
       }
     }
   };

--- a/lib/index.umd.js
+++ b/lib/index.umd.js
@@ -88,7 +88,7 @@
 
   let headings = [];
 
-  function gfmHeadingId({ prefix = '' } = {}) {
+  function gfmHeadingId({ prefix = '', focusable = false } = {}) {
     return {
       headerIds: false, // prevent deprecation warning; remove this once headerIds option is removed
       hooks: {
@@ -108,7 +108,7 @@
           const heading = { level, text, id };
           headings.push(heading);
 
-          return `<h${level} id="${id}">${text}</h${level}>\n`;
+          return `<h${level} id="${id}"${focusable ? ' tabindex="-1"' : ''}>${text}</h${level}>\n`;
         }
       }
     };

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -36,6 +36,21 @@ describe('marked-gfm-heading-id', () => {
 `);
   });
 
+  test('focusable', () => {
+    marked.use(gfmHeadingId({ focusable: true }));
+    const markdown = `
+# heading
+
+# heading
+`;
+
+    expect(marked(markdown)).toMatchInlineSnapshot(`
+"<h1 id="heading" tabindex="-1">heading</h1>
+<h1 id="heading-1" tabindex="-1">heading</h1>
+"
+`);
+  });
+
   test('reset for new marked call', () => {
     marked.use(gfmHeadingId());
     const markdown = `

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,6 +4,14 @@ import type {MarkedExtension, marked} from 'marked';
 interface GfmHeadingIdOptions {
   /** A string to prepend to all ids. Empty by default. */
   prefix?: string;
+
+  /**
+   * If set to `true`, it includes the attribute `tabindex="-1"` to make headings
+   * focusable for accessibility.
+   *
+   * @default false
+   */
+  focusable?: boolean;
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ let slugger;
 
 let headings = [];
 
-export function gfmHeadingId({ prefix = '' } = {}) {
+export function gfmHeadingId({ prefix = '', focusable = false } = {}) {
   return {
     headerIds: false, // prevent deprecation warning; remove this once headerIds option is removed
     hooks: {
@@ -23,7 +23,7 @@ export function gfmHeadingId({ prefix = '' } = {}) {
         const heading = { level, text, id };
         headings.push(heading);
 
-        return `<h${level} id="${id}">${text}</h${level}>\n`;
+        return `<h${level} id="${id}"${focusable ? ' tabindex="-1"' : ''}>${text}</h${level}>\n`;
       }
     }
   };


### PR DESCRIPTION
Allowing users to set the attribute `tabindex="-1"` for improved accessibility.