### PR TITLE
fix: remove tags from headings

### DIFF
--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -132,21 +132,26 @@ describe('marked-gfm-heading-id', () => {
     expect(headings[1].id).toBe('foo');
     expect(headings[2].id).toBe('foo-2');
     expect(headings[3].id).toBe('html-in-header');
+    expect(headings[3].text).toBe('Html in header');
     expect(headings[4].id).toBe('just-test');
     expect(headings[5].id).toBe('just-test-2');
 
     expect(headings[6].id).toBe('just--test-2-spaces-');
     expect(headings[7].id).toBe('just-test-3');
     expect(headings[8].id).toBe('just-test-4');
+    expect(headings[8].text).toBe('just test 4');
     expect(headings[9].id).toBe('just-non-tags');
     expect(headings[10].id).toBe('just-spaces');
 
     expect(headings[11].id).toBe('just--weird-chars');
+    expect(headings[11].text).toBe('just &lt;#$%&gt; weird chars');
     expect(headings[12].id).toBe('followed-by-weird-chars');
-    expect(headings[13].id).toBe('followed--space-then-weird-chars');
+    expect(headings[13].text).toBe('followed  space then weird chars');
     expect(headings[14].id).toBe('');
     expect(headings[15].id).toBe('comment-');
     expect(headings[16].id).toBe('hello-world');
+    expect(headings[16].text).toBe('Hello world!');
     expect(headings[17].id).toBe('hello-world-1');
+    expect(headings[17].text).toBe('Hello world!');
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ export function gfmHeadingId({ prefix = '' } = {}) {
           .trim()
           .replace(/<[!\/a-z].*?>/gi, '');
         const id = `${prefix}${slugger.slug(raw)}`;
-        const heading = { level, text, id };
+        const heading = { level, text: text.replace(/<[!\/a-z].*?>/gi, ''), id };
         headings.push(heading);
 
         return `<h${level} id="${id}">${text}</h${level}>\n`;


### PR DESCRIPTION
With the previous implementation, the headings contained HTML tags. 

This commit removes them. 